### PR TITLE
Use random seed for database key on recording logouts

### DIFF
--- a/domain_mapping.php
+++ b/domain_mapping.php
@@ -144,9 +144,9 @@ function dm_domains_admin() {
 				}
 			break;
 			case "save":
-				if ( $_POST[ 'blog_id' ] != 0 AND 
-					$_POST[ 'blog_id' ] != 1 AND 
-					null == $wpdb->get_var( $wpdb->prepare( "SELECT domain FROM {$wpdb->dmtable} WHERE blog_id != %d AND domain = %s", $_POST[ 'blog_id' ], $domain ) ) 
+				if ( $_POST[ 'blog_id' ] != 0 AND
+					$_POST[ 'blog_id' ] != 1 AND
+					null == $wpdb->get_var( $wpdb->prepare( "SELECT domain FROM {$wpdb->dmtable} WHERE blog_id != %d AND domain = %s", $_POST[ 'blog_id' ], $domain ) )
 				) {
 					if ( $_POST[ 'orig_domain' ] == '' ) {
 						$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->dmtable} ( `blog_id`, `domain`, `active` ) VALUES ( %d, %s, %d )", $_POST[ 'blog_id' ], $domain, $_POST[ 'active' ] ) );
@@ -486,7 +486,7 @@ function dm_manage_page() {
 	echo "<input type='checkbox' name='primary' value='1' /> " . __( 'Primary domain for this blog', 'wordpress-mu-domain-mapping' ) . "</p>";
 	echo "<p><input type='submit' class='button-secondary' value='" . __( "Add", 'wordpress-mu-domain-mapping' ) . "' /></p>";
 	echo "</form><br />";
-	
+
 	if ( get_site_option( 'dm_cname' ) ) {
 		$dm_cname = get_site_option( 'dm_cname');
 		echo "<p>" . sprintf( __( 'If you want to redirect a domain you will need to add a DNS "CNAME" record pointing to the following domain name for this server: <strong>%s</strong>', 'wordpress-mu-domain-mapping' ), $dm_cname ) . "</p>";
@@ -550,14 +550,14 @@ function get_original_url( $url, $blog_id = 0 ) {
 	global $wpdb;
 
 	if ( $blog_id != 0 ) {
-		$id = $blog_id; 
+		$id = $blog_id;
 	} else {
 		$id = $wpdb->blogid;
 	}
 
 	static $orig_urls = array();
 	if ( ! isset( $orig_urls[ $id ] ) ) {
-		if ( defined( 'DOMAIN_MAPPING' ) ) 
+		if ( defined( 'DOMAIN_MAPPING' ) )
 			remove_filter( 'pre_option_' . $url, 'domain_mapping_' . $url );
 		if ( $blog_id == 0 ) {
 			$orig_url = get_option( $url );
@@ -574,7 +574,7 @@ function get_original_url( $url, $blog_id = 0 ) {
 		} else {
 			$orig_urls[ $blog_id ] = $orig_url;
 		}
-		if ( defined( 'DOMAIN_MAPPING' ) ) 
+		if ( defined( 'DOMAIN_MAPPING' ) )
 			add_filter( 'pre_option_' . $url, 'domain_mapping_' . $url );
 	}
 	return $orig_urls[ $id ];
@@ -639,7 +639,7 @@ function redirect_login_to_orig() {
 	}
 }
 
-// fixes the plugins_url 
+// fixes the plugins_url
 function domain_mapping_plugins_uri( $full_url, $path=NULL, $plugin=NULL ) {
     $plugin_dir_pos = stripos( $full_url, PLUGINDIR );
 
@@ -676,7 +676,7 @@ if ( defined( 'DOMAIN_MAPPING' ) ) {
 	add_filter( 'plugins_url', 'domain_mapping_post_content' );
 } else {
 	add_filter( 'admin_url', 'domain_mapping_adminurl', 10, 3 );
-}	
+}
 add_action( 'admin_init', 'dm_redirect_admin' );
 if ( isset( $_GET[ 'dm' ] ) )
 	add_action( 'template_redirect', 'remote_login_js' );
@@ -686,12 +686,12 @@ function remote_logout_loader() {
 	$wpdb->dmtablelogins = $wpdb->base_prefix . 'domain_mapping_logins';
 	$protocol = is_ssl() ? 'https://' : 'http://';
 	$hash = get_dm_hash();
-	$key = md5( time() );
+	$key = md5( time() . mt_rand() );
 	$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->dmtablelogins} ( `id`, `user_id`, `blog_id`, `t` ) VALUES( %s, 0, %d, NOW() )", $key, $current_blog->blog_id ) );
 	if ( get_site_option( 'dm_redirect_admin' ) ) {
 		wp_redirect( $protocol . $current_site->domain . $current_site->path . "?dm={$hash}&action=logout&blogid={$current_blog->blog_id}&k={$key}&t=" . mt_rand() );
 		exit;
-	} 
+	}
 }
 
 function redirect_to_mapped_domain() {
@@ -795,7 +795,7 @@ function delete_blog_domain_mapping( $blog_id, $drop ) {
 		// Get an array of domain names to pass onto any delete_blog_domain_mapping actions
 		$domains = $wpdb->get_col( $wpdb->prepare( "SELECT domain FROM {$wpdb->dmtable} WHERE blog_id  = %d", $blog_id ) );
 		do_action('dm_delete_blog_domain_mappings', $domains);
-		
+
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->dmtable} WHERE blog_id  = %d", $blog_id ) );
 	}
 }
@@ -811,7 +811,7 @@ add_filter( 'wpmu_blogs_columns', 'ra_domain_mapping_columns' );
 function ra_domain_mapping_field( $column, $blog_id ) {
 	global $wpdb;
 	static $maps = false;
-	
+
 	if ( $column == 'map' ) {
 		if ( $maps === false ) {
 			$wpdb->dmtable = $wpdb->base_prefix . 'domain_mapping';


### PR DESCRIPTION
Fixes errors that looks like this:

```
[15-Oct-2019 19:08:37 UTC] WordPress database error Duplicate entry
'3dacb6a42aa8fdd12a56637ffbcd4f63'  for key 'PRIMARY' for query 
INSERT INTO wp_domain_mapping_logins ( `id`, `user_id`, `blog_id`, `t` ) 
VALUES( '3dacb6a42aa8fdd12a56637ffbcd4f63', 0, 4, NOW() )
```

The entry recorded in the domain_mapping_logins table by the logout handler was just using the unix timestamp as a database key. This caused duplicate inserts in logging out when a user would be logged out of multiple sites in the same second. 

This change adds a random string to that key to ensure uniqueness (which is the same functionality being used [on remote logins](https://github.com/voceconnect/wordpress-mu-domain-mapping/blob/master/domain_mapping.php#L746) already.)

_Note: I'm not 100% sure why the key is being generated like this anyways, rather than just using an auto-increment key. I suspect the reasons are lost in the sands of time. But rather than do a major reachitecting I thought this would be a simple fix._

